### PR TITLE
Abort process when panic occurs in any thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.1.8] - 2020-03-16
+
 ### Fixed
+- jvm collector now properly collects metrics for processes with a PID greater than 65535
 - panics will now abort the application to avoid dead collectors or a dead bosun emitter going unnoticed
 
 
@@ -25,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - MongoDB collector automatically recognizes if replSetGetStatus is suitable. In case of mongos or non replicated mongod, this metric is omitted.
 
 
-[Unreleased]: https://github.com/lukaspustina/ceres/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/lukaspustina/ceres/compare/v0.1.8...HEAD
+[v0.1.8]: https://github.com/lukaspustina/ceres/compare/v0.1.7...v0.1.8
 [v0.1.7]: https://github.com/lukaspustina/ceres/compare/v0.1.6...v0.1.7
 [v0.1.6]: https://github.com/lukaspustina/ceres/compare/v0.1.5...v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- panics will now abort the application to avoid dead collectors or a dead bosun emitter going unnoticed
+
 
 ## [0.1.7] - 2018-06-18
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,6 +41,7 @@
 - [ ] Move project to Rheinwerk
 - [ ] Extend bosun_emitter to send multiple data points
 - [ ] Support multiple Galera Collectors -- also change in Ansible role
+- [ ] Make threads resilient against panics (current workaround: abort on panic so that no thread dies unknowingly)
 
 ## Collectors
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,20 +51,6 @@ fn main() {
     run(&config);
 }
 
-fn print_panic_and_abort(info: &std::panic::PanicInfo<'_>) {
-    if let Some(loc) = info.location() {
-        println!("Application panicked at {}", loc);
-    } else {
-        println!("Application panicked");
-    }
-
-    if let Some(msg) = info.payload().downcast_ref::<&str>() {
-        println!("Reason: {}", msg);
-    }
-
-    std::process::abort()
-}
-
 fn init_logger() -> Result<(), SetLoggerError> {
     use log::{LogRecord, LogLevelFilter};
     use env_logger::LogBuilder;
@@ -101,6 +87,20 @@ fn parse_args(cli_args: &ArgMatches) -> Result<Config, Box<dyn Error>> {
     };
 
     Ok(config)
+}
+
+fn print_panic_and_abort(info: &std::panic::PanicInfo<'_>) {
+    if let Some(loc) = info.location() {
+        println!("Application panicked at {}", loc);
+    } else {
+        println!("Application panicked");
+    }
+
+    if let Some(msg) = info.payload().downcast_ref::<&str>() {
+        println!("Reason: {}", msg);
+    }
+
+    std::process::abort()
 }
 
 fn run(config: &Config) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,23 @@ fn main() {
         println!("config: {:?}", config);
     }
 
+    std::panic::set_hook(Box::new(print_panic_and_abort));
+
     run(&config);
+}
+
+fn print_panic_and_abort(info: &std::panic::PanicInfo<'_>) {
+    if let Some(loc) = info.location() {
+        println!("Application panicked at {}", loc);
+    } else {
+        println!("Application panicked");
+    }
+
+    if let Some(msg) = info.payload().downcast_ref::<&str>() {
+        println!("Reason: {}", msg);
+    }
+
+    std::process::abort()
 }
 
 fn init_logger() -> Result<(), SetLoggerError> {
@@ -96,7 +112,6 @@ fn exit_with_error(msg: &str, exit_code: i32) -> ! {
     println!("{}", msg);
     std::process::exit(exit_code);
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This should protect against threads dying unknowingly.
(ex. Bosun thread panics -> rs-collector doesn't send metrics)

see [PanicInfo](https://doc.rust-lang.org/std/panic/struct.PanicInfo.html) regarding the usage of `.location` and `.payload`